### PR TITLE
Add interfaces in order to test bulk stuff with mocks

### DIFF
--- a/force/bulk.go
+++ b/force/bulk.go
@@ -264,11 +264,11 @@ type BulkJob struct {
 	// AssignmentRuleId string `json:"assignmentRuleId,omitempty"` // null string
 }
 
-// BulkJobI interface for BulkJob api
-type BulkJobI interface {
+// BulkJober interface for BulkJob api
+type BulkJober interface {
 	// AddBatch adds a new batch to a job by sending a POST request to the following URI.
 	// The request body contains a list of records for processing.
-	AddBatch(batch []byte) (BatchI, error)
+	AddBatch(batch []byte) (Batcher, error)
 
 	// Close the job, starts executing the batches.
 	Close() (err error)
@@ -291,7 +291,7 @@ func (forceAPI *API) CreateBulkJob(
 	contentType ContentType,
 	operation Operation,
 	mode ConcurrencyMode,
-) (BulkJobI, error) {
+) (BulkJober, error) {
 	uri := fmt.Sprintf(`/services/async/%s/job`, strings.TrimPrefix(forceAPI.apiVersion, `v`))
 
 	req := &BulkJobReq{
@@ -313,7 +313,7 @@ func (forceAPI *API) CreateBulkJob(
 
 // AddBatch adds a new batch to a job by sending a POST request to the following URI.
 // The request body contains a list of records for processing.
-func (b *BulkJob) AddBatch(batch []byte) (BatchI, error) {
+func (b *BulkJob) AddBatch(batch []byte) (Batcher, error) {
 	uri := fmt.Sprintf(`/services/async/%.1f/job/%s/batch`, b.APIVersion, b.ID)
 
 	var resp Batch
@@ -445,8 +445,8 @@ type Batch struct {
 	ApexProcessingTime      int64  `json:"apexProcessingTime,omitempty"`      // The number of milliseconds taken to process triggers and other processes related to the batch data.
 }
 
-// BatchI interface for Batch api
-type BatchI interface {
+// Batcher interface for Batch api
+type Batcher interface {
 	// Info gets information about an existing batch.
 	Info() (err error)
 

--- a/force/bulk.go
+++ b/force/bulk.go
@@ -1,5 +1,4 @@
-//
-// Salesforce BULK API is used to upload larger data sets, it supports CSV,
+// Package force - Salesforce BULK API is used to upload larger data sets, it supports CSV,
 // XML and JSON as input format. It consists of jobs which contain one ore more
 // data batches.
 //
@@ -265,9 +264,34 @@ type BulkJob struct {
 	// AssignmentRuleId string `json:"assignmentRuleId,omitempty"` // null string
 }
 
+// BulkJobI interface for BulkJob api
+type BulkJobI interface {
+	// AddBatch adds a new batch to a job by sending a POST request to the following URI.
+	// The request body contains a list of records for processing.
+	AddBatch(batch []byte) (BatchI, error)
+
+	// Close the job, starts executing the batches.
+	Close() (err error)
+
+	// Abort the job.
+	Abort() (err error)
+
+	// Info of the current job.
+	Info() (err error)
+
+	// GetBatchesInfo gets information about all batches in a job.
+	GetBatchesInfo() (batchInfo *BulkJobBatches, err error)
+}
+
 // CreateBulkJob creates an Bulk API 2.0 Job.
 // sObjectExtID used for upsert and should be empty if not needed.
-func (forceAPI *API) CreateBulkJob(sObjectname string, sObjectExtID string, contentType ContentType, operation Operation, mode ConcurrencyMode) (*BulkJob, error) {
+func (forceAPI *API) CreateBulkJob(
+	sObjectname string,
+	sObjectExtID string,
+	contentType ContentType,
+	operation Operation,
+	mode ConcurrencyMode,
+) (BulkJobI, error) {
 	uri := fmt.Sprintf(`/services/async/%s/job`, strings.TrimPrefix(forceAPI.apiVersion, `v`))
 
 	req := &BulkJobReq{
@@ -289,7 +313,7 @@ func (forceAPI *API) CreateBulkJob(sObjectname string, sObjectExtID string, cont
 
 // AddBatch adds a new batch to a job by sending a POST request to the following URI.
 // The request body contains a list of records for processing.
-func (b *BulkJob) AddBatch(batch []byte) (*Batch, error) {
+func (b *BulkJob) AddBatch(batch []byte) (BatchI, error) {
 	uri := fmt.Sprintf(`/services/async/%.1f/job/%s/batch`, b.APIVersion, b.ID)
 
 	var resp Batch
@@ -421,6 +445,24 @@ type Batch struct {
 	ApexProcessingTime      int64  `json:"apexProcessingTime,omitempty"`      // The number of milliseconds taken to process triggers and other processes related to the batch data.
 }
 
+// BatchI interface for Batch api
+type BatchI interface {
+	// Info gets information about an existing batch.
+	Info() (err error)
+
+	// Request gets the request of a batch.
+	Request() ([]BatchRequest, error)
+
+	// Result gets results of a batch that has completed processing.
+	Result() ([]BatchResult, error)
+
+	// GetState returns batch status
+	GetState() BatchState
+
+	// GetNumberRecordsFailed return number of failed records
+	GetNumberRecordsFailed() int
+}
+
 // Info gets information about an existing batch.
 func (b *Batch) Info() (err error) {
 	uri := fmt.Sprintf(`/services/async/%.1f/job/%s/batch/%s`, b.APIVersion, b.JobID, b.ID)
@@ -475,4 +517,14 @@ func (b *Batch) Result() ([]BatchResult, error) {
 		return batchResult, fmt.Errorf("Bulk API: Can't retrieve Result for Batch '%s': %s", b.ID, err)
 	}
 	return batchResult, nil
+}
+
+// GetState returns batch status
+func (b *Batch) GetState() BatchState {
+	return b.State
+}
+
+// GetNumberRecordsFailed return number of failed records
+func (b *Batch) GetNumberRecordsFailed() int {
+	return b.NumberRecordsFailed
 }

--- a/force/example_bulk_test.go
+++ b/force/example_bulk_test.go
@@ -92,17 +92,17 @@ func Example_Bulk() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		switch batch.State {
+		switch batch.GetState() {
 		case force.BatchStateCompleted:
-			if batch.NumberRecordsFailed > 0 {
+			if batch.GetNumberRecordsFailed() > 0 {
 				log.Errorf("some records failed during processing: %d",
 					job.NumberRecordsFailed)
 			}
-    			break 
-    		case force.BatchStateFailed:
+			break
+		case force.BatchStateFailed:
 			log.Error("job failed")
 			break
-    		}
+		}
 		time.Sleep(time.Second * 15)
 	}
 }

--- a/force/sobjects.go
+++ b/force/sobjects.go
@@ -159,6 +159,18 @@ func (forceAPI *API) UpsertSObjectStringByExternalID(object, extenalID, id, data
 	return
 }
 
+// UpsertSObjectStringByID performs an upsert using an
+// ID and the JSON string representation of an SObject.
+func (forceAPI *API) UpsertSObjectStringByID(object, ID, data string) (resp *SObjectResponse, err error) {
+
+	uri := strings.Replace(forceAPI.apiSObjects[object].URLs[rowTemplateKey], idKey, ID, 1)
+
+	resp = &SObjectResponse{}
+	err = forceAPI.Patch(uri, nil, nil, data, resp)
+
+	return
+}
+
 // DeleteSObjectByExternalID deletes an SObject by external ID.
 func (forceAPI *API) DeleteSObjectByExternalID(id string, in SObject) (err error) {
 	uri := fmt.Sprintf("%v/%v/%v", forceAPI.apiSObjects[in.APIName()].URLs[sObjectKey],
@@ -187,7 +199,7 @@ func (forceAPI *API) GetSObjectList(object string) ([]SObjectRecord, error) {
 	resp := &SObjectList{}
 
 	qry := fmt.Sprintf("SELECT Id, Name FROM %s", object)
-	err := forceAPI.Query(qry, nil,resp)
+	err := forceAPI.Query(qry, nil, resp)
 	if err != nil {
 		return nil, fmt.Errorf("Cannot get object list for '%s': %s", object, err)
 	}


### PR DESCRIPTION
In order to test bulk functionality with mock, added interfaces to BulkJob and Batch.
`UpsertSObjectStringByID` added since its used in project and seems like was added to vendored sources.
Added methods for getting struct fields in order to correctly mock structs, mentioned above.